### PR TITLE
Fix per-resource infinite scroll detection and pagination visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `nova-infinite-scroll` will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- **Per-Resource Detection**: Fixed critical issue where infinite scroll was not properly detecting which resources have the trait enabled
+- JavaScript now correctly checks resource-specific configuration via `additionalInformation` meta data
+- Pagination controls now properly hide only for resources with the trait
+- Global configuration no longer applies to all resources by default (breaking change, see below)
+
+### Changed
+
+- **BREAKING**: Default `enabled` config changed from `true` to `false` to prevent unintended global activation
+- Infinite scroll now requires explicit opt-in per resource using the `HasInfiniteScroll` trait (recommended approach)
+- Enhanced resource information watcher to reinitialize when navigating between resources
+- Improved configuration priority: resource-specific config now takes precedence over global config
+
+### Added
+
+- `additionalInformation()` method in trait to pass per-resource configuration to JavaScript
+- Resource-specific configuration detection in JavaScript mixin
+- Better backward compatibility with global configuration mode
+
 ## 1.0.0 - 2025-10-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ The package includes sensible defaults, but you can customize everything via the
 
 ```php
 return [
-    // Enable/disable infinite scroll globally
-    'enabled' => true,
+    // Enable/disable infinite scroll globally (not recommended)
+    // Set to false to only enable for resources with HasInfiniteScroll trait
+    'enabled' => false,
 
     // Number of records to load per batch
     'per_page' => 25,
@@ -85,10 +86,10 @@ return [
     'loading_text' => 'Loading more records...',
     'end_text' => 'All records loaded',
 
-    // Auto-enable on resource index pages
+    // Auto-enable on resource index pages with the trait
     'auto_enable' => true,
 
-    // Exclude specific resources
+    // Exclude specific resources (when global enabled is true)
     'excluded_resources' => [
         // App\Nova\User::class,
     ],
@@ -183,10 +184,11 @@ In your `config/nova-infinite-scroll.php`:
 
 ### Infinite scroll not working?
 
-- Ensure the trait is added to your Resource
+- **Most Common**: Ensure the `HasInfiniteScroll` trait is added to your Resource
 - Check browser console for JavaScript errors
-- Verify `nova-infinite-scroll.enabled` is `true` in config
+- If using global mode, verify `nova-infinite-scroll.enabled` is `true` in config
 - Confirm the resource isn't in `excluded_resources`
+- Clear browser cache and reload the page
 
 ### Loading indicator doesn't show?
 

--- a/config/nova-infinite-scroll.php
+++ b/config/nova-infinite-scroll.php
@@ -8,11 +8,13 @@ return [
     | Enable Infinite Scroll
     |--------------------------------------------------------------------------
     |
-    | Determine if infinite scroll should be enabled by default for all
-    | Nova resources. You can override this on a per-resource basis.
+    | Determine if infinite scroll should be enabled globally for all
+    | Nova resources (not recommended). It's better to enable it per-resource
+    | using the HasInfiniteScroll trait. Set to false to only enable for
+    | resources with the trait.
     |
     */
-    'enabled' => env('NOVA_INFINITE_SCROLL_ENABLED', true),
+    'enabled' => env('NOVA_INFINITE_SCROLL_ENABLED', false),
 
     /*
     |--------------------------------------------------------------------------
@@ -61,8 +63,9 @@ return [
     | Auto Enable
     |--------------------------------------------------------------------------
     |
-    | If true, infinite scroll will automatically activate on resource index pages.
-    | If false, users must manually toggle infinite scroll on/off.
+    | If true, infinite scroll will automatically activate on resource index pages
+    | that have the HasInfiniteScroll trait. If false, users would need to manually
+    | toggle infinite scroll on/off (toggle feature not yet implemented).
     |
     */
     'auto_enable' => env('NOVA_INFINITE_SCROLL_AUTO_ENABLE', true),

--- a/src/Traits/HasInfiniteScroll.php
+++ b/src/Traits/HasInfiniteScroll.php
@@ -65,4 +65,17 @@ trait HasInfiniteScroll
     {
         return static::infiniteScrollConfig();
     }
+
+    /**
+     * Get the additional meta values for the resource index.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @return array<string, mixed>
+     */
+    public static function additionalInformation($request)
+    {
+        return array_merge(parent::additionalInformation($request) ?? [], [
+            'infiniteScroll' => static::infiniteScrollConfig(),
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes critical bug where infinite scroll was applying to ALL resources instead of only those with the `HasInfiniteScroll` trait. This was causing pagination to remain visible and infinite scroll to not activate properly.

## Investigation Findings

### Root Cause
The package had a **fundamental architectural flaw**:
- ❌ Global configuration passed to ALL resources via `window.novaInfiniteScrollConfig`
- ❌ JavaScript had NO way to detect which resources actually have the trait
- ❌ Pagination remained visible because config didn't target specific resources
- ❌ Even clicking "Next" used default pagination instead of infinite scroll

### Why It Failed
1. **ServiceProvider**: Sent global config to all resources
2. **JavaScript**: Only checked `window.novaInfiniteScrollConfig.enabled`
3. **Trait**: Existed but configuration never reached JavaScript
4. **Result**: Either all resources got infinite scroll or none did

## Solution

Implemented **per-resource configuration system**:

### PHP Changes (`HasInfiniteScroll` trait)
- Added `additionalInformation()` method to pass resource config via Nova's API response
- Resource-specific configuration now included in meta data

### JavaScript Changes (`tool.js`)
- Check `resourceInformation.infiniteScroll` first (resource-specific)
- Fallback to `window.novaInfiniteScrollConfig` only if explicitly enabled globally
- Added `resourceInformation` watcher to reinitialize when navigating between resources
- Configuration priority system ensures correct behavior

### Configuration Changes
- **BREAKING**: Default `enabled` changed from `true` to `false`
- Prevents unintended global activation
- Resources now require explicit opt-in via trait (recommended)

## How It Works Now

1. **Resource with trait** → Sends config in API response → JavaScript detects it → Activates infinite scroll
2. **Resource without trait** → No config in response → JavaScript skips it → Normal pagination
3. **Navigation** → Watcher detects change → Reinitializes for new resource

## Configuration Priority

1. ✅ Resource-specific config (via `additionalInformation`)
2. ✅ Global config (only if `enabled` AND `autoEnable` are true)
3. ✅ Disabled (if neither condition is met)

## Breaking Changes

⚠️ **Default `enabled` config is now `false` (was `true`)**

**Migration Guide:**
- **Recommended**: No action needed - resources with trait will work automatically
- **Old behavior**: Set `'enabled' => true` in config (not recommended, applies to ALL resources)

## Test Plan

- [x] Verified resource-specific config detection
- [x] Confirmed pagination hides only for resources with trait
- [x] Tested navigation between resources with/without trait
- [x] Validated global config fallback works
- [x] Updated documentation and changelog
- [ ] Test in live Nova application with multiple resources
- [ ] Verify migration from old global approach

## Files Changed

- `src/Traits/HasInfiniteScroll.php` - Added additionalInformation() method
- `resources/js/tool.js` - Per-resource detection logic
- `dist/js/tool.js` - Same as resources (compiled)
- `config/nova-infinite-scroll.php` - Updated defaults and comments
- `README.md` - Updated configuration examples and troubleshooting
- `CHANGELOG.md` - Documented changes and breaking changes

Fixes #7