### PR TITLE
Fix critical pagination bug for resources without infinite scroll trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ All notable changes to `nova-infinite-scroll` will be documented in this file.
 
 ### Fixed
 
+- **CRITICAL**: Fixed broken default pagination that made resources unusable when package was installed
+- Removed selectPage override that was breaking normal pagination for resources without the trait
+- Infinite scroll now uses its own loading method without interfering with Nova's pagination
 - **Per-Resource Detection**: Fixed critical issue where infinite scroll was not properly detecting which resources have the trait enabled
 - JavaScript now correctly checks resource-specific configuration via `additionalInformation` meta data
 - Pagination controls now properly hide only for resources with the trait
 - Global configuration no longer applies to all resources by default (breaking change, see below)
+- Added proper cleanup of CSS classes when destroying infinite scroll
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ In your `config/nova-infinite-scroll.php`:
 - Confirm the resource isn't in `excluded_resources`
 - Clear browser cache and reload the page
 
+### Default pagination not working?
+
+If you're experiencing issues with default pagination (clicking "Next" does nothing), ensure you're using the latest version. Versions prior to 1.1.0 had a critical bug that broke pagination for resources without the trait.
+
 ### Loading indicator doesn't show?
 
 - Check if Nova's default styles are loaded


### PR DESCRIPTION
## Summary

Fixes a **critical bug** where default pagination stopped working for resources that don't have the HasInfiniteScroll trait, making those resources completely unusable.

## Root Cause

The infiniteScrollSelectPage method was overriding the selectPage method for ALL resources in the Nova admin panel. When a resource without the HasInfiniteScroll trait tried to use pagination, the override would check for originalSelectPage and return early without calling any pagination logic, effectively breaking all pagination functionality.

## Changes Made

- **Removed** the selectPage override completely
- Infinite scroll now uses its own dedicated loadMoreViaInfiniteScroll method
- This method directly fetches and appends resources without interfering with Nova's built-in pagination
- Resources **without** the trait now use Nova's default pagination normally
- Resources **with** the trait get infinite scrolling without breaking pagination
- Added proper cleanup of CSS classes in destroyInfiniteScroll

## Testing

- Resources without the HasInfiniteScroll trait now have working pagination
- Resources with the HasInfiniteScroll trait still have infinite scrolling
- Filters, search, and sorting continue to work correctly with infinite scroll

## Documentation

- Updated CHANGELOG.md with critical fix notice
- Updated README.md with troubleshooting section for pagination issues

Fixes #9